### PR TITLE
Fix anonymous AMD builds.

### DIFF
--- a/tasks/packager.js
+++ b/tasks/packager.js
@@ -19,7 +19,8 @@ module.exports = function(grunt) {
         var packager = new Packager(file.src[0], {export: options.export || data.export});
         output = packager.toLocals();
       } else {
-        var compiler = new Compiler(grunt.file.read(file.src[0]), file.src[0], options);
+        var moduleName = options.anonymous ? null : file.src[0],
+            compiler = new Compiler(grunt.file.read(file.src[0]), moduleName, options);
         if (type === 'cjs') {
           output = compiler.toCJS();
         } else if (type === 'amd') {


### PR DESCRIPTION
Currently, we are always passing the moduleName to the Compiler which it then
interprets as non-anonymous.

This came up while attempting to fix the Handlebars AMD builds (they
currently ignore the `anonymous: true` option that is specified in the
Gruntfile).
